### PR TITLE
Update QM platform for qibolab 0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The following versions were used to perform the benchmarks presented in the pape
 
 Library | Version
 -- | --
-`qibolab` | 0.1.0
-`qibocal` | 0.0.3
+`qibolab` | 0.1.6
+`qibocal` | 0.0.4
 `qblox-instruments` | 0.9.0
-`qm-qua` | 1.1.1
+`qm-qua` | 1.1.6
 `laboneq` | 2.7.0
 `qick` | 0.2.135
 `qibosoq` | 0.0.3

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains the code required to reproduce the benchmarks presented in Section IV.A. of the [qibolab paper](https://arxiv.org/abs/2308.06313).
 
+Note that the main branch of this repository is being updated to newer versions of the Python libraries.
+For the versions used in the benchmark please check the [v0.1.0 tag](https://github.com/qiboteam/qibolab-benchmarks/tree/v0.1.0).
+
 ## Required libraries
 
 Executing the benchmarks on instruments requires installing the [qibolab](https://qibo.science/qibolab/stable/getting-started/installation.html)

--- a/platforms/qm/parameters.json
+++ b/platforms/qm/parameters.json
@@ -1,0 +1,68 @@
+{
+    "nqubits": 1,
+    "settings": {
+        "nshots": 4096,
+        "relaxation_time": 300000
+    },
+    "qubits": [
+        0
+    ],
+    "topology": [],
+    "instruments": {
+        "con3": {
+            "i1": {
+                "gain": 0
+            },
+            "i2": {
+                "gain": 0
+            }
+        },
+        "lo_readout": {
+            "frequency": 5000000000,
+            "power": 0
+        },
+        "lo_drive": {
+            "frequency": 3900000000,
+            "power": 0
+        }
+    },
+    "native_gates": {
+        "single_qubit": {
+            "0": {
+                "RX": {
+                    "duration": 40,
+                    "amplitude": 0.005,
+                    "frequency": 4098114578,
+                    "shape": "Gaussian(5)",
+                    "type": "qd",
+                    "start": 0,
+                    "phase": 0
+                },
+                "MZ": {
+                    "duration": 2000,
+                    "amplitude": 0.005,
+                    "frequency": 5228200000,
+                    "shape": "Rectangular()",
+                    "type": "ro",
+                    "start": 0,
+                    "phase": 0
+                }
+            }
+        }
+    },
+    "characterization": {
+        "single_qubit": {
+            "0": {
+                "readout_frequency": 5228200000,
+                "drive_frequency": 4098114578,
+                "T1": 0.0,
+                "T2": 0.0,
+                "sweetspot": 0,
+                "mean_gnd_states": "1.5417+0.1817j",
+                "mean_exc_states": "2.5332-0.5914j",
+                "threshold": 0.4906,
+                "iq_angle": 1.336
+            }
+        }
+    }
+}

--- a/platforms/qm/parameters.yml
+++ b/platforms/qm/parameters.yml
@@ -7,6 +7,19 @@ settings:
 
 qubits: [0]
 
+instruments:
+    con3:
+        i1:
+            gain: 0
+        i2:
+            gain: 0
+    lo_readout:
+        frequency: 5_000_000_000
+        power: 0
+    lo_drive:
+        frequency: 3_900_000_000
+        power: 0
+
 native_gates:
     single_qubit:
         0: # qubit number

--- a/platforms/qm/platform.py
+++ b/platforms/qm/platform.py
@@ -1,19 +1,24 @@
 import pathlib
 
 from qibolab.channels import ChannelMap
-from qibolab.instruments.qm import QMOPX
+from qibolab.instruments.qm import OPXplus, QMController
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
-NAME = "qmopx"
 ADDRESS = "192.168.0.101:80"
 TIME_OF_FLIGHT = 280
-RUNCARD = pathlib.Path(__file__).parent / "qm.yml"
+FOLDER = pathlib.Path(__file__).parent
 
 
-def create(runcard_path=RUNCARD):
-    controller = QMOPX(NAME, ADDRESS, time_of_flight=TIME_OF_FLIGHT)
+def create():
+    opx = OPXplus("con3")
+    controller = QMController("qm", ADDRESS, opxs=[opx], time_of_flight=TIME_OF_FLIGHT)
     # Instantiate local oscillators
     lo_drive = SGS100A("lo_drive", "192.168.0.35")
     lo_readout = SGS100A("lo_readout", "192.168.0.36")
@@ -21,18 +26,11 @@ def create(runcard_path=RUNCARD):
     # Create channel objects
     channels = ChannelMap()
     channels |= ("readout", "feedback", "drive", "twpa")
-    channels["readout"].port = controller[(("con3", 9), ("con3", 10))]
-    channels["feedback"].port = controller[(("con3", 1), ("con3", 2))]
-    channels["drive"].port = controller[(("con3", 3), ("con3", 4))]
-
-    # add gain to feedback channels
-    # channels["feedback"].gain = 15
-
-    # Configure local oscillator's frequency and power
-    lo_readout.frequency = 5_000_000_000
-    lo_readout.power = 18
-    lo_drive.frequency = 3_900_000_000
-    lo_drive.power = 18
+    channels["readout"].port = controller.ports((("con3", 9), ("con3", 10)))
+    channels["feedback"].port = controller.ports(
+        (("con3", 1), ("con3", 2)), output=False
+    )
+    channels["drive"].port = controller.ports((("con3", 3), ("con3", 4)))
 
     # Assign local oscillators to channels
     channels["readout"].local_oscillator = lo_readout
@@ -40,8 +38,8 @@ def create(runcard_path=RUNCARD):
     channels["drive"].local_oscillator = lo_drive
 
     # create qubit objects
-    runcard = load_runcard(runcard_path)
-    qubits, pairs = load_qubits(runcard)
+    runcard = load_runcard(FOLDER)
+    qubits, couplers, pairs = load_qubits(runcard)
 
     # assign channels to qubit
     qubit = qubits[0]
@@ -49,6 +47,7 @@ def create(runcard_path=RUNCARD):
     qubit.feedback = channels["feedback"]
     qubit.drive = channels["drive"]
 
-    instruments = {inst.name: inst for inst in [controller, lo_readout, lo_drive]}
+    instruments = {inst.name: inst for inst in [controller, opx, lo_readout, lo_drive]}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("qm", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/runcards/routines_benchmarks.yml
+++ b/runcards/routines_benchmarks.yml
@@ -49,13 +49,14 @@ actions:
 
   - id: ramsey detuned
     priority: 40
-    operation: ramsey
+    operation: ramsey_signal
     main: t1
     parameters:
       delay_between_pulses_start: 0
       delay_between_pulses_end: 30_000
       delay_between_pulses_step: 1_000
       n_osc: 10
+      unrolling: False
 
   - id: t1
     priority: 50


### PR DESCRIPTION
Updates the QM platform to work with the latest version of qibolab and the driver. We should slowly propagate this to all platforms.

I also changed the ramsey detuned to use `ramsey_signal` because this type of acquisition was used in the original paper (in case we want to still use it as baseline).